### PR TITLE
FLUX 1 / Added support for the basic FLUX 1 model, but apparently the backend does not expect this

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ dist/
 # OpenAPI output
 generated/
 swagger.json
+
+# IntelliJ IDEA
+.idea
+
+# Goose
+.goose

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "civitai",
-  "version": "0.1.2",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "civitai",
-      "version": "0.1.2",
+      "version": "0.1.14",
       "dependencies": {
         "tslib": "^2.6.2",
         "zod": "^3.22.4"

--- a/src/Civitai.ts
+++ b/src/Civitai.ts
@@ -69,7 +69,21 @@ class Civitai {
         }
 
         // Infer the baseModel from the model value
-        const baseModel = input.model.includes("sdxl") ? "SDXL" : "SD_1_5";
+        const modelKeywordsMap: Record<string, string> = {
+          sdxl: "SDXL",
+          flux1: "Flux1",
+        };
+        
+        const determineBaseModel = (modelUri: string): string => {
+          for (const keyword in modelKeywordsMap) {
+            if (modelUri.includes(keyword)) {
+              return modelKeywordsMap[keyword];
+            }
+          }
+          return "SD_1_5";
+        };
+        
+        const baseModel = determineBaseModel(input.model);
 
         // Prepare job input with default values
         const jobInput = {

--- a/src/types/Inputs.ts
+++ b/src/types/Inputs.ts
@@ -12,6 +12,7 @@ export interface CivitaiConfig {
 export type FromComfyInput = {
   params?: Record<string, any> | null;
   callbackUrl?: string;
+  quantity?: number;
 };
 
 export type FromTextInput = {

--- a/src/validation/ValidationSchemas.ts
+++ b/src/validation/ValidationSchemas.ts
@@ -37,6 +37,7 @@ export const fromTextSchema = z
           .object({
             strength: z.number().optional(),
             triggerWord: z.string().optional(),
+            type: z.string().optional(),
           })
           .strict()
       )

--- a/test/createFromComfy.test.ts
+++ b/test/createFromComfy.test.ts
@@ -1,5 +1,5 @@
 import Civitai from "../dist/Civitai";
-import { FromComfyInput } from "../dist/models/InputTypes";
+import { FromComfyInput } from "../dist/types/Inputs";
 import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";

--- a/test/getJobStatus.test.ts
+++ b/test/getJobStatus.test.ts
@@ -5,8 +5,6 @@ dotenv.config({ path: ".env.test" });
 describe("Get Job Status by Token Functionality", () => {
   let civitai: Civitai;
   const jobId = "a2916035-7a89-4d1e-b6c9-1810f113f456";
-  const token: string =
-    "eyJKb2JzIjpbIjVkOTI5MGJiLTkwNmUtNDM0MC1iY2I3LTRmYTA4YTJjN2ZlYyJdfQ";
 
   beforeAll(() => {
     civitai = new Civitai({


### PR DESCRIPTION
It might come in handy as soon as the back starts accepting this format. The Civita front can send to FLUX, and the data there is not much different. I'm ready to finish the drink as soon as the back is ready